### PR TITLE
Start adding production build tasks to gulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 npm-debug.log
 css
 fonts
+js/dist

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,22 @@ gulp.task('copy-fonts', function() {
       .pipe(gulp.dest('./css'));
 });
 
+gulp.task('buildjs', function() {
+  return gulp.src ([
+      './bower_components/jquery/dist/jquery.js',
+      './bower_components/what-input/what-input.js',
+      './bower_components/foundation-sites/dist/foundation.js',
+      './js/app.js',
+      './js/partials/push-menu.js',
+      './js/partials/uthsc.section-nav.js'
+      ])
+      .pipe($.concat('uthsc.js'))
+      .pipe(gulp.dest('./js/dist'))
+      .pipe($.uglify())
+      .pipe($.rename('uthsc.min.js'))
+      .pipe(gulp.dest('./js/dist'));
+});
+
 gulp.task('default', ['sass','copy-fonts'], function() {
   gulp.watch(['scss/**/*.scss'], ['sass']);
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
-    "gulp-rename": "^1.2.2"
+    "gulp-rename": "^1.2.2",
+    "gulp-concat": "^2.6.0"
   },
   "scripts": {
     "start": "gulp",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "gulp-load-plugins": "^1.1.0",
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^1.5.1"
+    "gulp-uglify": "^1.5.1",
+    "gulp-rename": "^1.2.2"
   },
   "scripts": {
     "start": "gulp",


### PR DESCRIPTION
This just adds concat and rename to gulp and sets up a task to concatenate and uglify js and move the output to the right place.
Eventually we will need to move css as well.
To do: look in to webpack and browserfy to deal with assets
