### PR TITLE
removed meta tags for twitter cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,18 +12,6 @@
     <meta property="og:title" content="xxxx">
     <meta property="og:description" content="xxxx">
     <meta property="og:image" content="https://uthsc.edu/xxxx">
-
-    <!-- twitter card tags additive with the og: tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:domain" value="uthsc.edu">
-    <meta name="twitter:title" value="xxxx">
-    <meta name="twitter:description" value="xxxx">
-    <meta name="twitter:image" content="https://uthsc.edu/xxxx">
-    <meta name="twitter:url" value="https://www.uthsc.edu/xxxx">
-    <meta name="twitter:label1" value="xxxx">
-    <meta name="twitter:data1" value="xxxx">
-    <meta name="twitter:label2" value="xxxx">
-    <meta name="twitter:data2" value="xxxx">
     <!--/unfurling-->
 
     <title>Foundation for Sites</title>


### PR DESCRIPTION
pretty simple. deleted twitter meta tags. we will add them in as necessary and then maybe put them into the template if it becomes big enough.
