### PR TITLE
Fix homepage mobile tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,18 +175,18 @@
     <!--**********************-->
     <!--Emergency Notification-->
     <!--**********************-->
-    <div class="row expanded hide-for-print">
-        <div class="columns callout alert large-12" style="margin-bottom:0; padding:0;" data-closable>
-            <div class="row">
-                <h2>Emergency Notification!</h2>
-                <p>This section will be used for emergency notifications.</p>
+    <!--<div class="row expanded hide-for-print">-->
+        <!--<div class="columns callout alert large-12" style="margin-bottom:0; padding:0;" data-closable>-->
+            <!--<div class="row">-->
+                <!--<h2>Emergency Notification!</h2>-->
+                <!--<p>This section will be used for emergency notifications.</p>-->
 
-                <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-        </div>
-    </div>
+                <!--<button class="close-button" aria-label="Dismiss alert" type="button" data-close>-->
+                    <!--<span aria-hidden="true">&times;</span>-->
+                <!--</button>-->
+            <!--</div>-->
+        <!--</div>-->
+    <!--</div>-->
     <!--***********************-->
     <!--/Emergency Notification-->
     <!--***********************-->

--- a/scss/partials/_uthsc-anchortext.scss
+++ b/scss/partials/_uthsc-anchortext.scss
@@ -31,5 +31,17 @@
     }
   }
 
+  //Reset mobile tabs
+  .tabs .tabs-title a {
+    background-image:none;
+    text-shadow: none;
+
+    &:hover {
+      background-image:none;
+      text-shadow: none;
+    }
+
+  }
+
 }
 

--- a/scss/partials/_uthsc-homepage.scss
+++ b/scss/partials/_uthsc-homepage.scss
@@ -5,22 +5,8 @@
     }
 
     //Homepage mobile tabs
-
-    .tabs {
-    //  margin-top: -2px;
-    }
-    .tabs dd > a, .tabs .tab-title > a {
-    //  padding: 0;
-    //  padding-bottom: .75rem;
-    }
-
-    h2.tab-header {
-    //  color: $secondary-color;
-    }
-
     ul.tabs li {
       width: 24%;
-
       a {
         padding: .5em;
         text-align: center;
@@ -29,32 +15,10 @@
           background-color: $uthsc-gray-light;
         }
       }
-    //  padding-top: 1rem;
       &.tabs-title > a[aria-selected='true'] {
         background-color: $uthsc-gray-dark;
-    //    position: relative;
-    //    top: 2px;
-    //    border: 2px solid #00a5e3;
-    //    border-bottom: none;
-    //    border-top: none;
-    //    a {
-    //      background-color: transparent;
-    //    }
       }
     }
-    //.tabs-content {
-    //  border: 2px solid #00a5e3;
-    //  background-color: #f5f5f5;
-    //  .college-image {
-    //    margin-bottom: 2rem;
-    //  }
-    //  .small-news .news-box {
-    //    padding: 0 !important;
-    //  }
-    //}
-    //.tabs-content .columns:not(.mission-image):not(.college-image) {
-    //  padding: 0 1rem;
-    //}
     //End Homepage mobile tabs
 
     .columns.mission-image {

--- a/scss/partials/_uthsc-homepage.scss
+++ b/scss/partials/_uthsc-homepage.scss
@@ -3,44 +3,60 @@
     .hero {
       margin-top: 1rem;
     }
+
+    //Homepage mobile tabs
+
     .tabs {
-      margin-top: -2px;
+    //  margin-top: -2px;
     }
     .tabs dd > a, .tabs .tab-title > a {
-      padding: 0;
-      padding-bottom: .75rem;
+    //  padding: 0;
+    //  padding-bottom: .75rem;
     }
+
     h2.tab-header {
-      color: $secondary-color;
+    //  color: $secondary-color;
     }
+
     ul.tabs li {
-      width: 25%;
-      padding-top: 1rem;
-      &.tab-title.active {
-        background-color: #f5f5f5;
-        position: relative;
-        top: 2px;
-        border: 2px solid #00a5e3;
-        border-bottom: none;
-        border-top: none;
-        a {
-          background-color: transparent;
+      width: 24%;
+
+      a {
+        padding: .5em;
+        text-align: center;
+
+        &:hover {
+          background-color: $uthsc-gray-light;
         }
       }
-    }
-    .tabs-content {
-      border: 2px solid #00a5e3;
-      background-color: #f5f5f5;
-      .college-image {
-        margin-bottom: 2rem;
+    //  padding-top: 1rem;
+      &.tabs-title > a[aria-selected='true'] {
+        background-color: $uthsc-gray-dark;
+    //    position: relative;
+    //    top: 2px;
+    //    border: 2px solid #00a5e3;
+    //    border-bottom: none;
+    //    border-top: none;
+    //    a {
+    //      background-color: transparent;
+    //    }
       }
-      .small-news .news-box {
-        padding: 0 !important;
-      }
     }
-    .tabs-content .columns:not(.mission-image):not(.college-image) {
-      padding: 0 1rem;
-    }
+    //.tabs-content {
+    //  border: 2px solid #00a5e3;
+    //  background-color: #f5f5f5;
+    //  .college-image {
+    //    margin-bottom: 2rem;
+    //  }
+    //  .small-news .news-box {
+    //    padding: 0 !important;
+    //  }
+    //}
+    //.tabs-content .columns:not(.mission-image):not(.college-image) {
+    //  padding: 0 1rem;
+    //}
+    //End Homepage mobile tabs
+
     .columns.mission-image {
       margin-top: -15px;
     }

--- a/scss/partials/_uthsc-homepage.scss
+++ b/scss/partials/_uthsc-homepage.scss
@@ -5,20 +5,26 @@
     }
 
     //Homepage mobile tabs
-    ul.tabs li {
-      width: 24%;
-      a {
-        padding: .5em;
-        text-align: center;
+    ul.tabs {
+      margin-right: 0;
+      left: auto;
 
-        &:hover {
-          background-color: $uthsc-gray-light;
+      li {
+        width: 25%;
+        a {
+          padding: .5em;
+          text-align: center;
+
+          &:hover {
+            background-color: $uthsc-gray-light;
+          }
+        }
+        &.tabs-title > a[aria-selected='true'] {
+          background-color: $uthsc-gray-dark;
         }
       }
-      &.tabs-title > a[aria-selected='true'] {
-        background-color: $uthsc-gray-dark;
-      }
     }
+
     //End Homepage mobile tabs
 
     .columns.mission-image {


### PR DESCRIPTION
This mostly just fixes bugs. Added a reset for the anchor text decoration that was being applied to the tabs. Also, the tabs markup changed a lot from Foundation 5 to Foundation 6 so there were some old broken styles hanging around that have been deleted. These tabs may still need to be styled up some but all of the stuff that was broken is fixed.
