### PR TITLE
updated class names

### DIFF
--- a/nursing/index.php
+++ b/nursing/index.php
@@ -316,14 +316,14 @@
                         <!--**********-->
                         <!--Page intro-->
                         <!--**********-->
-                        <h3 class="page-intro">Since our founding in 1887 the UTHSC College of Nursing (CON) has been
+                        <h3 class="uthsc-page-intro">Since our founding in 1887 the UTHSC College of Nursing (CON) has been
                             at the forefront of nursing education, scholarship, and innovation.</h3>
 
 
                         <!--*********-->
                         <!--Page lead-->
                         <!--*********-->
-                        <p class="page-lead">We were the first nursing school in the Mid-South. We have lead the way by
+                        <p class="uthsc-page-lead">We were the first nursing school in the Mid-South. We have lead the way by
                             focusing on the science and practice of nursing. Our rigorous and supportive
                             multidisciplinary environment offers the full spectrum of academic nursing training. We
                             provide graduate degrees and specialized certifications to prepare you for a career in

--- a/research/index.php
+++ b/research/index.php
@@ -327,7 +327,7 @@
                         <!--**********-->
                         <!--Page intro-->
                         <!--**********-->
-                        <h3 class="page-intro">Each fiscal year, our faculty and staff receive
+                        <h3 class="uthsc-page-intro">Each fiscal year, our faculty and staff receive
                             nearly $100 million in research funding, including support from National Institutes of
                             Health grants and private foundations. </h3>
 
@@ -335,7 +335,7 @@
                         <!--*********-->
                         <!--Page lead-->
                         <!--*********-->
-                        <p class="page-lead">Advancing research and economic development is at the core of our mission.
+                        <p class="uthsc-page-lead">Advancing research and economic development is at the core of our mission.
                             Research funding has directly contributed to UTHSC's long record of accomplishments in basic
                             science, applied clinical and translational
                             research, and public health, allowing us to continue our contributions to the health of the


### PR DESCRIPTION
when porting to OUC there were two class names that weren't uthsc prefixed. Those were updated in both the research and nursing pages.
